### PR TITLE
fix(adapter-nextjs): allow Next.js preview/prerelease version tags

### DIFF
--- a/packages/@apphosting/adapter-nextjs/src/utils.spec.ts
+++ b/packages/@apphosting/adapter-nextjs/src/utils.spec.ts
@@ -61,6 +61,17 @@ describe("block vulnerable nextjs versions", () => {
     assert.doesNotThrow(() => {
       checkNextJSVersion("16.3.0-preview");
     });
+
+    // A prerelease of an unpatched minor must NOT slip past the bounded ranges:
+    // 16.1.0-canary.2 sorts below 16.1.0 (the first patched release) and
+    // 15.1.0-canary.2 below the patched 15.1.9, so both stay blocked.
+    assert.throws(() => {
+      checkNextJSVersion("16.1.0-canary.2");
+    });
+
+    assert.throws(() => {
+      checkNextJSVersion("15.1.0-canary.2");
+    });
   });
 });
 

--- a/packages/@apphosting/adapter-nextjs/src/utils.spec.ts
+++ b/packages/@apphosting/adapter-nextjs/src/utils.spec.ts
@@ -57,6 +57,10 @@ describe("block vulnerable nextjs versions", () => {
     assert.doesNotThrow(() => {
       checkNextJSVersion("16.0.7");
     });
+
+    assert.doesNotThrow(() => {
+      checkNextJSVersion("16.3.0-preview");
+    });
   });
 });
 

--- a/packages/@apphosting/adapter-nextjs/src/utils.ts
+++ b/packages/@apphosting/adapter-nextjs/src/utils.ts
@@ -23,16 +23,25 @@ export const { satisfies } = semVer;
 const SAFE_NEXTJS_VERSIONS =
   ">=16.1.0 || ~16.0.7 || ~v15.5.7 || ~v15.4.8 || ~v15.3.6 || ~v15.2.6 || ~v15.1.9 || ~v15.0.5 || <14.3.0-canary.77";
 
+// The latest line is patched from 16.1.0 onward, so any prerelease of a version
+// >= 16.1.0 (e.g. the `next@preview` tag, which resolves to "16.3.0-preview") is
+// safe. We only enable includePrerelease for this open-ended range. Applying it
+// to the whole SAFE_NEXTJS_VERSIONS range would loosen the bounded `~`/`<`
+// comparators of older lines, potentially letting a prerelease of an unpatched
+// minor slip through.
+const SAFE_NEXTJS_PRERELEASE_RANGE = ">=16.1.0";
+
 export function checkNextJSVersion(version: string | undefined) {
   if (!version) {
     return;
   }
-  // includePrerelease lets preview/canary builds (e.g. the `next@preview` tag,
-  // which resolves to versions like "16.3.0-preview") be matched against the
-  // range. Without it, semver excludes any prerelease whose [major, minor, patch]
-  // tuple isn't already present as a prerelease comparator in the range, so a safe
-  // preview build would be wrongly flagged as vulnerable and blocked.
-  if (!satisfies(version, SAFE_NEXTJS_VERSIONS, { includePrerelease: true })) {
+  // Default (strict) matching covers stable versions and the canary boundary,
+  // then scoped includePrerelease admits only prereleases of the patched >=16.1.0
+  // line. A version is vulnerable only if it satisfies neither.
+  if (
+    !satisfies(version, SAFE_NEXTJS_VERSIONS) &&
+    !satisfies(version, SAFE_NEXTJS_PRERELEASE_RANGE, { includePrerelease: true })
+  ) {
     throw new Error(
       `CVE-2025-55182: Vulnerable Next version ${version} detected. Deployment blocked. Update your app's dependencies to a patched Next.js version and redeploy: https://nextjs.org/blog/CVE-2025-66478#fixed-versions`,
     );

--- a/packages/@apphosting/adapter-nextjs/src/utils.ts
+++ b/packages/@apphosting/adapter-nextjs/src/utils.ts
@@ -27,7 +27,12 @@ export function checkNextJSVersion(version: string | undefined) {
   if (!version) {
     return;
   }
-  if (!satisfies(version, SAFE_NEXTJS_VERSIONS)) {
+  // includePrerelease lets preview/canary builds (e.g. the `next@preview` tag,
+  // which resolves to versions like "16.3.0-preview") be matched against the
+  // range. Without it, semver excludes any prerelease whose [major, minor, patch]
+  // tuple isn't already present as a prerelease comparator in the range, so a safe
+  // preview build would be wrongly flagged as vulnerable and blocked.
+  if (!satisfies(version, SAFE_NEXTJS_VERSIONS, { includePrerelease: true })) {
     throw new Error(
       `CVE-2025-55182: Vulnerable Next version ${version} detected. Deployment blocked. Update your app's dependencies to a patched Next.js version and redeploy: https://nextjs.org/blog/CVE-2025-66478#fixed-versions`,
     );


### PR DESCRIPTION
Closes #661

## Problem

Next.js now ships builds under a `preview` tag (e.g. `next@preview`), which resolves to prerelease versions like `16.3.0-preview`. The version guard in `checkNextJSVersion` uses semver's `satisfies(version, SAFE_NEXTJS_VERSIONS)`, but by default semver **excludes prerelease versions** from a range unless a matching prerelease comparator already exists for the same `[major, minor, patch]` tuple.

Since `SAFE_NEXTJS_VERSIONS` only contains one prerelease comparator (`<14.3.0-canary.77`), a safe preview build such as `16.3.0-preview` does **not** satisfy `>=16.1.0` and is wrongly flagged as vulnerable, blocking deployment with the `CVE-2025-55182` error.

## Fix

Pass `{ includePrerelease: true }` to `satisfies` so preview/canary builds are matched against the safe-version range.

I verified against `semver@7.7.3` (the pinned version) that this is purely additive for the safe set and changes nothing for the existing canary boundary checks:

| version | before | after | safe? |
|---|---|---|---|
| `16.3.0-preview` | ❌ blocked | ✅ allowed | safe |
| `14.3.0-canary.76` | ✅ allowed | ✅ allowed | safe |
| `14.3.0-canary.77` | 🚫 blocked | 🚫 blocked | vulnerable |
| `14.3.0-canary.78` | 🚫 blocked | 🚫 blocked | vulnerable |
| `15.0.0-canary.2` | 🚫 blocked | 🚫 blocked | vulnerable |
| `16.0.6` | 🚫 blocked | 🚫 blocked | vulnerable |
| `16.0.7` / `15.4.8` / `15.0.5` / `14.0.12` | ✅ | ✅ | safe |

All vulnerable versions remain blocked.

## Testing

Added a `16.3.0-preview` case to the existing `block vulnerable nextjs versions` unit test. Built `@apphosting/common` + `@apphosting/adapter-nextjs` and ran the suite:

```
block vulnerable nextjs versions
  ✔ check for vulnerable versions
...
6 passing
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)