### PR TITLE
fix(nextjs): allow nextjs prerelease/preview versions to be deployed

### DIFF
--- a/packages/@apphosting/adapter-nextjs/src/utils.spec.ts
+++ b/packages/@apphosting/adapter-nextjs/src/utils.spec.ts
@@ -61,6 +61,14 @@ describe("block vulnerable nextjs versions", () => {
     assert.doesNotThrow(() => {
       checkNextJSVersion("16.3.0-preview");
     });
+
+    assert.throws(() => {
+      checkNextJSVersion("15.6.0-canary.1");
+    });
+
+    assert.throws(() => {
+      checkNextJSVersion("16.1.0-canary.1");
+    });
   });
 });
 

--- a/packages/@apphosting/adapter-nextjs/src/utils.spec.ts
+++ b/packages/@apphosting/adapter-nextjs/src/utils.spec.ts
@@ -57,6 +57,10 @@ describe("block vulnerable nextjs versions", () => {
     assert.doesNotThrow(() => {
       checkNextJSVersion("16.0.7");
     });
+
+    assert.doesNotThrow(() => {
+      checkNextJSVersion("16.3.0-preview");
+    });
   });
 });
 

--- a/packages/@apphosting/adapter-nextjs/src/utils.ts
+++ b/packages/@apphosting/adapter-nextjs/src/utils.ts
@@ -22,12 +22,19 @@ export const { satisfies } = semVer;
 
 const SAFE_NEXTJS_VERSIONS =
   ">=16.1.0 || ~16.0.7 || ~v15.5.7 || ~v15.4.8 || ~v15.3.6 || ~v15.2.6 || ~v15.1.9 || ~v15.0.5 || <14.3.0-canary.77";
+const STRICTLY_SAFE_NEXTJS_VERSIONS =
+  "==16.1.0 || >=16.1.1 || ~16.0.8 || ~v15.5.8 || ~v15.4.9 || ~v15.3.7 || ~v15.2.7 || ~v15.1.10 || ~v15.0.6 || <14.3.0-canary.77";
 
 export function checkNextJSVersion(version: string | undefined) {
   if (!version) {
     return;
   }
-  if (!satisfies(version, SAFE_NEXTJS_VERSIONS, { includePrerelease: true })) {
+  const isPrerelease = semVer.prerelease(version) !== null;
+  const baseVersion = isPrerelease ? semVer.coerce(version)?.version : null;
+  const isSafe = satisfies(version, SAFE_NEXTJS_VERSIONS) ||
+    (baseVersion && satisfies(baseVersion, STRICTLY_SAFE_NEXTJS_VERSIONS));
+
+  if (!isSafe) {
     throw new Error(
       `CVE-2025-55182: Vulnerable Next version ${version} detected. Deployment blocked. Update your app's dependencies to a patched Next.js version and redeploy: https://nextjs.org/blog/CVE-2025-66478#fixed-versions`,
     );

--- a/packages/@apphosting/adapter-nextjs/src/utils.ts
+++ b/packages/@apphosting/adapter-nextjs/src/utils.ts
@@ -27,7 +27,7 @@ export function checkNextJSVersion(version: string | undefined) {
   if (!version) {
     return;
   }
-  if (!satisfies(version, SAFE_NEXTJS_VERSIONS)) {
+  if (!satisfies(version, SAFE_NEXTJS_VERSIONS, { includePrerelease: true })) {
     throw new Error(
       `CVE-2025-55182: Vulnerable Next version ${version} detected. Deployment blocked. Update your app's dependencies to a patched Next.js version and redeploy: https://nextjs.org/blog/CVE-2025-66478#fixed-versions`,
     );


### PR DESCRIPTION
By passing `{ includePrerelease: true }` to `semver.satisfies`, preview/prerelease builds like `16.3.0-preview` will pass the vulnerability check. Real vulnerable canary versions will remain blocked.

Fixes #661
Fixes b/529799040