### PR TITLE
fix: point repository.url at the renamed repo

### DIFF
--- a/packages/@apphosting/adapter-angular/package.json
+++ b/packages/@apphosting/adapter-angular/package.json
@@ -5,7 +5,7 @@
   "description": "Experimental addon to the Firebase CLI to add web framework support",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/FirebaseExtended/firebase-framework-tools.git"
+    "url": "git+https://github.com/firebase/apphosting-adapters.git"
   },
   "bin": {
     "apphosting-adapter-angular-build": "dist/bin/build.js",

--- a/packages/@apphosting/adapter-nextjs/package.json
+++ b/packages/@apphosting/adapter-nextjs/package.json
@@ -5,7 +5,7 @@
   "description": "Experimental addon to the Firebase CLI to add web framework support",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/FirebaseExtended/firebase-framework-tools.git"
+    "url": "git+https://github.com/firebase/apphosting-adapters.git"
   },
   "bin": {
     "apphosting-adapter-nextjs-build": "dist/bin/build.js",

--- a/packages/@apphosting/build/package.json
+++ b/packages/@apphosting/build/package.json
@@ -5,7 +5,7 @@
     "description": "Experimental addon to the Firebase CLI to run local builds",
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/FirebaseExtended/firebase-framework-tools.git"
+        "url": "git+https://github.com/firebase/apphosting-adapters.git"
     },
     "bin": {
         "apphosting-local-build": "dist/bin/localbuild.js"

--- a/packages/@apphosting/common/package.json
+++ b/packages/@apphosting/common/package.json
@@ -13,7 +13,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/FirebaseExtended/firebase-framework-tools.git"
+    "url": "git+https://github.com/firebase/apphosting-adapters.git"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/@apphosting/create/package.json
+++ b/packages/@apphosting/create/package.json
@@ -5,7 +5,7 @@
     "description": "Experimental addon to the Firebase CLI to add web framework support",
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/FirebaseExtended/firebase-framework-tools.git"
+        "url": "git+https://github.com/firebase/apphosting-adapters.git"
     },
     "bin": {
         "create": "dist/bin/create.js"

--- a/packages/@apphosting/discover/package.json
+++ b/packages/@apphosting/discover/package.json
@@ -5,7 +5,7 @@
     "description": "Experimental addon to the Firebase CLI to add web framework support",
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/FirebaseExtended/firebase-framework-tools.git"
+        "url": "git+https://github.com/firebase/apphosting-adapters.git"
     },
     "bin": {
         "discover": "dist/bin/discover.js"

--- a/packages/@apphosting/experimental/adapter-astro/package.json
+++ b/packages/@apphosting/experimental/adapter-astro/package.json
@@ -18,7 +18,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/FirebaseExtended/firebase-framework-tools.git"
+        "url": "git+https://github.com/firebase/apphosting-adapters.git"
       },
     "files": [
       "dist"

--- a/packages/create-next-on-firebase/package.json
+++ b/packages/create-next-on-firebase/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/FirebaseExtended/firebase-framework-tools.git"
+    "url": "git+https://github.com/firebase/apphosting-adapters.git"
   },
   "author": "Firebase",
   "license": "Apache-2.0",

--- a/packages/firebase-frameworks/package.json
+++ b/packages/firebase-frameworks/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/FirebaseExtended/firebase-framework-tools.git"
+    "url": "git+https://github.com/firebase/apphosting-adapters.git"
   },
   "author": {
     "name": "Firebase",


### PR DESCRIPTION
Publishing `@apphosting/astro-adapter` failed provenance verification: https://github.com/firebase/apphosting-adapters/actions/runs/31425985094/job/93579115899#step:6:71

The repo was renamed to `firebase/apphosting-adapters` but no `package.json` was updated. Astro was simply the first package published since the rename; the other eight would fail the same way on their next release, so all are updated.