### PR TITLE
fix(nextjs): drop invalid comparator from strictly-safe version range

### DIFF
--- a/packages/@apphosting/adapter-nextjs/src/utils.ts
+++ b/packages/@apphosting/adapter-nextjs/src/utils.ts
@@ -23,7 +23,7 @@ export const { satisfies } = semVer;
 const SAFE_NEXTJS_VERSIONS =
   ">=16.1.0 || ~16.0.7 || ~v15.5.7 || ~v15.4.8 || ~v15.3.6 || ~v15.2.6 || ~v15.1.9 || ~v15.0.5 || <14.3.0-canary.77";
 const STRICTLY_SAFE_NEXTJS_VERSIONS =
-  "==16.1.0 || >=16.1.1 || ~16.0.8 || ~v15.5.8 || ~v15.4.9 || ~v15.3.7 || ~v15.2.7 || ~v15.1.10 || ~v15.0.6 || <14.3.0-canary.77";
+  ">=16.1.1 || ~16.0.8 || ~v15.5.8 || ~v15.4.9 || ~v15.3.7 || ~v15.2.7 || ~v15.1.10 || ~v15.0.6 || <14.3.0-canary.77";
 
 export function checkNextJSVersion(version: string | undefined) {
   if (!version) {


### PR DESCRIPTION
`Test Node 18` fails on main, skipping `Publish (NPM)` and blocking releases: https://github.com/firebase/apphosting-adapters/actions/runs/31520664730/job/93877364944#step:8:165

`STRICTLY_SAFE_NEXTJS_VERSIONS` starts with `==16.1.0`, which isn't valid semver — `new Range("==16.1.0")` throws `Invalid comparator`. One bad comparator invalidates the whole range, so `satisfies()` always returned false and the prerelease fallback from #665 never matched. Every prerelease was blocked.

Dropping the clause is enough; `>=16.1.1` already covers it. Repairing it to `=16.1.0` would instead allow `16.1.0-canary.1`, which predates the fix released in 16.1.0.