### PR TITLE
fix(nextjs): restore the user config when the override fails

### DIFF
--- a/packages/@apphosting/adapter-nextjs/src/bin/build.ts
+++ b/packages/@apphosting/adapter-nextjs/src/bin/build.ts
@@ -35,6 +35,8 @@ const nextConfig = await loadConfig(root, opts.projectDirectory);
  *
  * We restore the user's Next Config at the end of the build, after the config file has been
  * copied over to the output directory, so that the user's original code is not modified.
+ * The override and its validation run inside the try block so that the restore in the
+ * finally block also covers a failure in either of them.
  *
  * If the app does not have a next.config.[js|mjs|ts|mts] file in the first place,
  * then can skip config override.
@@ -43,12 +45,13 @@ const nextConfig = await loadConfig(root, opts.projectDirectory);
  * one does not exist in the app's root: https://github.com/vercel/next.js/blob/23681508ca34b66a6ef55965c5eac57de20eb67f/packages/next/src/server/config.ts#L1115
  */
 const nextConfigPath = join(root, nextConfig.configFileName);
-if (await exists(nextConfigPath)) {
-  await overrideNextConfig(root, nextConfig.configFileName);
-  await validateNextConfigOverride(root, opts.projectDirectory, nextConfig.configFileName);
-}
 
 try {
+  if (await exists(nextConfigPath)) {
+    await overrideNextConfig(root, nextConfig.configFileName);
+    await validateNextConfigOverride(root, opts.projectDirectory, nextConfig.configFileName);
+  }
+
   await runBuild();
 
   const adapterMetadata = getAdapterMetadata();

--- a/packages/@apphosting/adapter-nextjs/src/overrides.spec.ts
+++ b/packages/@apphosting/adapter-nextjs/src/overrides.spec.ts
@@ -349,6 +349,26 @@ describe("next config overrides", () => {
     );
   });
 
+  it("should leave the original config in place when the override fails", async () => {
+    const { overrideNextConfig } = await importOverrides;
+    const originalConfig = `module.exports = { /* config options here */ }`;
+
+    // ".cjs" stands in for any extension the override does not know how to rewrite. If it
+    // ever becomes supported, pick another unsupported extension rather than deleting this.
+    fs.writeFileSync(path.join(tmpDir, "next.config.cjs"), originalConfig);
+
+    await assert.rejects(
+      async () => await overrideNextConfig(tmpDir, "next.config.cjs"),
+      /Unsupported file extension for Next Config/,
+    );
+
+    assert.equal(fs.readFileSync(path.join(tmpDir, "next.config.cjs"), "utf-8"), originalConfig);
+    assert.ok(
+      !fs.existsSync(path.join(tmpDir, "next.config.original.cjs")),
+      "No next.config.original.cjs backup should be left behind",
+    );
+  });
+
   it("should not do anything if no next.config.* file exists", async () => {
     const { overrideNextConfig } = await importOverrides;
     await overrideNextConfig(tmpDir, "next.config.js");

--- a/packages/@apphosting/adapter-nextjs/src/overrides.ts
+++ b/packages/@apphosting/adapter-nextjs/src/overrides.ts
@@ -28,41 +28,47 @@ export async function overrideNextConfig(projectRoot: string, nextConfigFileName
   const fileExtension = extname(nextConfigFileName);
   const originalConfigName = `next.config.original${fileExtension}`;
 
+  // Create a new config file with the appropriate import. This runs before the original
+  // config file is renamed, so an unsupported extension fails while the user's project is
+  // still untouched.
+  let importStatement;
+  switch (fileExtension) {
+    case ".js":
+      importStatement = `const originalConfig = require('./${originalConfigName}');`;
+      break;
+    case ".mjs":
+    case ".mts":
+      importStatement = `import originalConfig from './${originalConfigName}';`;
+      break;
+    case ".ts":
+      importStatement = `import originalConfig from './${originalConfigName.replace(".ts", "")}';`;
+      break;
+    default:
+      throw new Error(
+        `Unsupported file extension for Next Config: "${fileExtension}", please use ".js", ".mjs", ".ts", or ".mts"`,
+      );
+  }
+
+  // Create the new config content with our overrides
+  const newConfigContent = getCustomNextConfig(importStatement, fileExtension);
+
   // Rename the original config file
+  let originalConfigRenamed = false;
   try {
     const originalPath = join(projectRoot, originalConfigName);
     await renamePromise(configPath, originalPath);
-
-    // Create a new config file with the appropriate import
-    let importStatement;
-    switch (fileExtension) {
-      case ".js":
-        importStatement = `const originalConfig = require('./${originalConfigName}');`;
-        break;
-      case ".mjs":
-      case ".mts":
-        importStatement = `import originalConfig from './${originalConfigName}';`;
-        break;
-      case ".ts":
-        importStatement = `import originalConfig from './${originalConfigName.replace(
-          ".ts",
-          "",
-        )}';`;
-        break;
-      default:
-        throw new Error(
-          `Unsupported file extension for Next Config: "${fileExtension}", please use ".js", ".mjs", ".ts", or ".mts"`,
-        );
-    }
-
-    // Create the new config content with our overrides
-    const newConfigContent = getCustomNextConfig(importStatement, fileExtension);
+    originalConfigRenamed = true;
 
     // Write the new config file
     await writeFile(join(projectRoot, nextConfigFileName), newConfigContent);
     console.log(`Successfully created ${nextConfigFileName} with Firebase App Hosting overrides`);
   } catch (error) {
     console.error(`Error overriding Next.js config: ${error}`);
+    // Move the original config file back, so a failed override does not leave the app
+    // without a Next Config at all.
+    if (originalConfigRenamed) {
+      await restoreNextConfig(projectRoot, nextConfigFileName);
+    }
     throw error;
   }
 }


### PR DESCRIPTION
`overrideNextConfig` renames the user's Next config before anything that can throw, and
`bin/build.ts` called it outside the `try` whose `finally` restores it. Any failure after the
rename left the project holding `next.config.original.<ext>` and no config at all, and a later
run does not recover it: `loadConfig` then reports the default `next.config.js`, so
`restoreNextConfig` looks for a backup under the wrong extension and returns early.

Cloud Build workspaces are ephemeral, but the adapter also runs locally through
`npm exec apphosting-adapter-nextjs-build`, where this mutates the developer's tree and does
not put it back.

The extension check and the config content now happen before the rename, the original is
restored if the write fails, and the override and its validation moved inside the `try`.

The new test covers the path that throws before the rename. The restore in the `catch` is
covered by inspection only, since making `writeFile` fail after a successful `rename` in the
same directory is not something I could drive from a unit test.

#684 shipped `.mts` support, which was the other half of #680.

Fixes #680
