### PR TITLE
fix(nextjs): support next.config.mts

### DIFF
--- a/packages/@apphosting/adapter-nextjs/src/bin/build.ts
+++ b/packages/@apphosting/adapter-nextjs/src/bin/build.ts
@@ -36,7 +36,7 @@ const nextConfig = await loadConfig(root, opts.projectDirectory);
  * We restore the user's Next Config at the end of the build, after the config file has been
  * copied over to the output directory, so that the user's original code is not modified.
  *
- * If the app does not have a next.config.[js|mjs|ts] file in the first place,
+ * If the app does not have a next.config.[js|mjs|ts|mts] file in the first place,
  * then can skip config override.
  *
  * Note: loadConfig always returns a fileName (default: next.config.js) even if

--- a/packages/@apphosting/adapter-nextjs/src/overrides.spec.ts
+++ b/packages/@apphosting/adapter-nextjs/src/overrides.spec.ts
@@ -319,6 +319,36 @@ describe("next config overrides", () => {
     );
   });
 
+  it("should set images.unoptimized to true - TypeScript ESM", async () => {
+    const { overrideNextConfig } = await importOverrides;
+    const originalConfig = `
+    import type { NextConfig } from 'next'
+
+    const nextConfig: NextConfig = {
+      /* config options here */
+    }
+
+    export default nextConfig
+    `;
+
+    fs.writeFileSync(path.join(tmpDir, "next.config.mts"), originalConfig);
+    await overrideNextConfig(tmpDir, "next.config.mts");
+
+    const updatedConfig = fs.readFileSync(path.join(tmpDir, "next.config.mts"), "utf-8");
+
+    assert.equal(
+      normalizeWhitespace(updatedConfig),
+      normalizeWhitespace(`
+      // @ts-nocheck
+      import originalConfig from './next.config.original.mts';
+
+      ${nextConfigOverrideBody}
+
+      export default config;
+      `),
+    );
+  });
+
   it("should not do anything if no next.config.* file exists", async () => {
     const { overrideNextConfig } = await importOverrides;
     await overrideNextConfig(tmpDir, "next.config.js");

--- a/packages/@apphosting/adapter-nextjs/src/overrides.ts
+++ b/packages/@apphosting/adapter-nextjs/src/overrides.ts
@@ -11,7 +11,7 @@ import { join, extname } from "path";
 import { rename as renamePromise } from "fs/promises";
 
 /**
- * Overrides the user's Next Config file (next.config.[ts|js|mjs]) to add configs
+ * Overrides the user's Next Config file (next.config.[ts|mts|js|mjs]) to add configs
  * optimized for Firebase App Hosting.
  */
 export async function overrideNextConfig(projectRoot: string, nextConfigFileName: string) {
@@ -40,6 +40,7 @@ export async function overrideNextConfig(projectRoot: string, nextConfigFileName
         importStatement = `const originalConfig = require('./${originalConfigName}');`;
         break;
       case ".mjs":
+      case ".mts":
         importStatement = `import originalConfig from './${originalConfigName}';`;
         break;
       case ".ts":
@@ -50,7 +51,7 @@ export async function overrideNextConfig(projectRoot: string, nextConfigFileName
         break;
       default:
         throw new Error(
-          `Unsupported file extension for Next Config: "${fileExtension}", please use ".js", ".mjs", or ".ts"`,
+          `Unsupported file extension for Next Config: "${fileExtension}", please use ".js", ".mjs", ".ts", or ".mts"`,
         );
     }
 
@@ -73,10 +74,11 @@ export async function overrideNextConfig(projectRoot: string, nextConfigFileName
  * - images.unoptimized = true, unless user explicitly sets images.unoptimized to false or
  * is using a custom image loader.
  * @param importStatement The import statement for the original config.
- * @param fileExtension The file extension of the original config. Use ".js", ".mjs", or ".ts"
+ * @param fileExtension The file extension of the original config. Use ".js", ".mjs", ".ts", or ".mts"
  * @return The custom Next.js config.
  */
 function getCustomNextConfig(importStatement: string, fileExtension: string) {
+  const isEsm = [".mjs", ".mts"].includes(fileExtension);
   return `
   // @ts-nocheck
   ${importStatement}
@@ -99,7 +101,7 @@ function getCustomNextConfig(importStatement: string, fileExtension: string) {
       }
     : fahOptimizedConfig(originalConfig);
 
-  ${fileExtension === ".mjs" ? "export default config;" : "module.exports = config;"}
+  ${isEsm ? "export default config;" : "module.exports = config;"}
   `;
 }
 
@@ -143,7 +145,7 @@ export async function validateNextConfigOverride(
 }
 
 /**
- * Restores the user's original Next Config file (next.config.original.[ts|js|mjs])
+ * Restores the user's original Next Config file (next.config.original.[ts|mts|js|mjs])
  * to leave user code the way we found it.
  */
 export async function restoreNextConfig(projectRoot: string, nextConfigFileName: string) {


### PR DESCRIPTION
Next.js supports next.config.mts, but the adapter threw an
unsupported-extension error for it.

.mts is always an ES module, so it is handled like .mjs:
the renamed original is imported with its extension and
the config is emitted as `export default`.

Fixes #680
