### PR TITLE
fix(firebase-frameworks): prepare the Next.js server once, not per request

### DIFF
--- a/packages/firebase-frameworks/src/next.js/index.ts
+++ b/packages/firebase-frameworks/src/next.js/index.ts
@@ -15,8 +15,10 @@ const nextApp: NextServer = createNextServer({
   port: 8080,
 });
 
+const preparePromise = nextApp.prepare();
+
 export const handle = async (req: Request, res: Response): Promise<void> => {
-  await nextApp.prepare();
+  await preparePromise;
   const parsedUrl = parse(req.url, true);
   const incomingMessage = incomingMessageFromExpress(req);
   await nextApp.getRequestHandler()(incomingMessage, res, parsedUrl);


### PR DESCRIPTION
## Problem

`handle()` called `await nextApp.prepare()` on every request. Since Next 13.4.15 that is no longer a no-op in production: each call re-runs the router server initialization, leaking a process-level error listener and rebuilding the render server, until the instance runs out of memory.

Fixes #574.

## Fix

Prepare once at module load and await the shared promise — matching the [documented custom server example](https://nextjs.org/docs/pages/guides/custom-server) and the existing `express`, `nuxt3` and `sveltekit` adapters.

## Verification

Deployed to Cloud Run at 512MiB. Next 14.2.35, 501 routes, 1500 requests.

Before: listeners grew by one per request, memory grew 0.47 MB per request, and the container was killed twice for exceeding its memory limit.

```
Memory limit of 512 MiB exceeded with 513 MiB used.
Memory limit of 512 MiB exceeded with 516 MiB used.
```

After: listeners flat at 3, memory flat at ~144 MB, zero restarts.